### PR TITLE
[1.19] Strip NBT data when breaking blank drawers

### DIFF
--- a/src/main/java/io/github/mattidragon/extendeddrawers/block/DrawerBlock.java
+++ b/src/main/java/io/github/mattidragon/extendeddrawers/block/DrawerBlock.java
@@ -188,6 +188,9 @@ public class DrawerBlock extends NetworkBlockWithEntity<DrawerBlockEntity> imple
     @Override
     public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
         if (builder.get(LootContextParameters.BLOCK_ENTITY) instanceof DrawerBlockEntity drawer) {
+            if (drawer.isBlank()) {
+                return List.of(new ItemStack(this.asItem(), 1));
+            }
             builder = builder.putDrop(id("drawer"), (context, consumer) -> {
                 for (var slot : drawer.storages) {
                     var amount = slot.getAmount();

--- a/src/main/java/io/github/mattidragon/extendeddrawers/block/entity/DrawerBlockEntity.java
+++ b/src/main/java/io/github/mattidragon/extendeddrawers/block/entity/DrawerBlockEntity.java
@@ -43,6 +43,15 @@ public class DrawerBlockEntity extends BlockEntity {
         sortSlots();
     }
 
+    public boolean isBlank() {
+        for (int i = 0; i < storages.length; i++) {
+            if (!storages[i].isBlank()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void sortSlots() {
         combinedStorage.parts.sort(null);
     }

--- a/src/main/java/io/github/mattidragon/extendeddrawers/drawer/DrawerSlot.java
+++ b/src/main/java/io/github/mattidragon/extendeddrawers/drawer/DrawerSlot.java
@@ -129,6 +129,10 @@ public final class DrawerSlot extends SnapshotParticipant<DrawerSlot.Snapshot> i
         return amount;
     }
 
+    public boolean isBlank() {
+        return this.isResourceBlank() && !this.isHidden() && !this.isLocked() && !this.isVoiding() && this.getUpgrade() == null;
+    }
+
     @Override
     public long getCapacity() {
         var config = CommonConfig.HANDLE.get();


### PR DESCRIPTION
Fixes #27 
I will admit, I don't fully understand how `getDroppedStacks` works, but in my testing this seems to have fixed the issue.
I am not sure what the builder bit actually does, though, so I don't know what else is affected by skipping it like this. I tested it with and without and it didn't seem to make any difference.