### PR TITLE
Ensure resource packs are compatible for 1.21

### DIFF
--- a/src/main/resources/resourcepacks/alt/pack.mcmeta
+++ b/src/main/resources/resourcepacks/alt/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 32,
+    "pack_format": 34,
     "description": "Alternative textures provided by LordDeatHunter"
   }
 }

--- a/src/main/resources/resourcepacks/dev/pack.mcmeta
+++ b/src/main/resources/resourcepacks/dev/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 32,
+    "pack_format": 34,
     "description": "Original programmer art"
   }
 }


### PR DESCRIPTION
`32` is a reference to 1.20.5-pre4 which is not supported by 1.21/1.21.1, therefore it must be `34` to be marked as compatible.